### PR TITLE
boards: ros_driver: select HAS_FLASH_LOAD_OFFSET

### DIFF
--- a/boards/waveshare/ros_driver/Kconfig.ros_driver
+++ b/boards/waveshare/ros_driver/Kconfig.ros_driver
@@ -4,3 +4,7 @@ config BOARD_ROS_DRIVER
 	select SOC_ESP32_WROOM_32UE_N4
 	select SOC_ESP32_PROCPU if BOARD_ROS_DRIVER_ESP32_PROCPU
 	select SOC_ESP32_APPCPU if BOARD_ROS_DRIVER_ESP32_APPCPU
+	# The board's partition table reserves slot0 at 0x10000; mark this so
+	# Zephyr's USE_DT_CODE_PARTITION can satisfy its dependency when sysbuild
+	# enables BOOTLOADER_MCUBOOT.
+	select HAS_FLASH_LOAD_OFFSET


### PR DESCRIPTION
The ros_driver board has slot0 reserved at flash offset 0x10000 for MCUboot OTA, but Zephyr's \`HAS_FLASH_LOAD_OFFSET\` symbol is not auto-set on ESP32. Without it, sysbuild builds with \`BOOTLOADER_MCUBOOT=y\` fail Kconfig because \`USE_DT_CODE_PARTITION\`'s declared deps don't satisfy.

Surfaced while trying to make the consumer's CI green on PR rosterloh/zephyr-applications#17.

## Test plan

- [x] \`west build -p auto -b ros_driver/esp32/procpu --sysbuild applications/rasprover\` no longer fails on Kconfig (in concert with the consumer-side prj.conf fixes in zephyr-applications#17).