### PR TITLE
drivers: dynamixel: fix uart_irq_update void return usage

### DIFF
--- a/drivers/dynamixel/dynamixel_serial.c
+++ b/drivers/dynamixel/dynamixel_serial.c
@@ -176,7 +176,9 @@ static void uart_cb_handler(const struct device *dev, void *app_data)
 
 	cfg = ctx->cfg;
 
-	while (uart_irq_update(cfg->dev) && uart_irq_is_pending(cfg->dev)) {
+	uart_irq_update(cfg->dev);
+
+	while (uart_irq_is_pending(cfg->dev)) {
 
 		if (uart_irq_rx_ready(cfg->dev)) {
 			cb_handler_rx(ctx);


### PR DESCRIPTION
uart_irq_update() now returns void in current Zephyr, so using it in the `while (uart_irq_update(dev) && ...)` condition fails to compile ("void value not ignored as it ought to be"). Call it unconditionally at ISR entry per the canonical UART interrupt pattern, then loop on uart_irq_is_pending().