### PR TITLE
ESP32 PCNT multi-unit encoder driver + ros_driver motor nodes

### DIFF
--- a/boards/waveshare/ros_driver/ros_driver-pinctrl.dtsi
+++ b/boards/waveshare/ros_driver/ros_driver-pinctrl.dtsi
@@ -51,8 +51,20 @@
 	ledc0_default: ledc0_default {
 		group1 {
 			pinmux = <LEDC_CH0_GPIO4>,
-				 <LEDC_CH1_GPIO5>;
+				 <LEDC_CH1_GPIO5>,
+				 <LEDC_CH2_GPIO25>,
+				 <LEDC_CH3_GPIO26>;
 			output-enable;
+		};
+	};
+
+	pcnt_default: pcnt_default {
+		group1 {
+			pinmux = <PCNT0_CH0SIG_GPIO35>,
+				 <PCNT0_CH0CTRL_GPIO34>,
+				 <PCNT1_CH0SIG_GPIO27>,
+				 <PCNT1_CH0CTRL_GPIO16>;
+			bias-pull-up;
 		};
 	};
 };

--- a/boards/waveshare/ros_driver/ros_driver_procpu.dts
+++ b/boards/waveshare/ros_driver/ros_driver_procpu.dts
@@ -19,6 +19,8 @@
 		uart-0 = &uart0;
 		i2c-0 = &i2c0;
 		watchdog0 = &wdt0;
+		left-motor = &left_motor;
+		right-motor = &right_motor;
 	};
 
 	chosen {
@@ -64,6 +66,33 @@
 			label = "BOOT Button";
 			zephyr,code = <INPUT_KEY_0>;
 		};
+	};
+
+	/* TB6612-style dual H-bridge. Vendor-positive drive is IN1 low /
+	 * IN2 high, so in1/in2 are swapped relative to the AIN1/AIN2
+	 * silkscreen names to make the driver's forward match the
+	 * vendor's forward while keeping brake = both-high.
+	 */
+	left_motor: motor_left {
+		compatible = "rosterloh,actuator-hbridge";
+		pwms = <&ledc0 2 PWM_HZ(100000) PWM_POLARITY_NORMAL>;
+		in1-gpios = <&gpio0 17 GPIO_ACTIVE_HIGH>; /* AIN2 */
+		in2-gpios = <&gpio0 21 GPIO_ACTIVE_HIGH>; /* AIN1 */
+		encoder = <&pcnt_unit0>;
+		pwm-period-ns = <10000>; /* 100 kHz, vendor-proven */
+		default-mode = "velocity";
+		label = "Left motor";
+	};
+
+	right_motor: motor_right {
+		compatible = "rosterloh,actuator-hbridge";
+		pwms = <&ledc0 3 PWM_HZ(100000) PWM_POLARITY_NORMAL>;
+		in1-gpios = <&gpio0 23 GPIO_ACTIVE_HIGH>; /* BIN2 */
+		in2-gpios = <&gpio0 22 GPIO_ACTIVE_HIGH>; /* BIN1 */
+		encoder = <&pcnt_unit1>;
+		pwm-period-ns = <10000>;
+		default-mode = "velocity";
+		label = "Right motor";
 	};
 };
 
@@ -135,6 +164,14 @@
 		reg = <0x1>;
 		timer = <1>;
 	};
+	channel2@2 {
+		reg = <0x2>;
+		timer = <2>;
+	};
+	channel3@3 {
+		reg = <0x3>;
+		timer = <3>;
+	};
 };
 
 &timer0 {
@@ -202,4 +239,37 @@
 
 &esp32_bt_hci {
 	status = "okay";
+};
+
+&pcnt {
+	compatible = "rosterloh,esp32-pcnt";
+	pinctrl-0 = <&pcnt_default>;
+	pinctrl-names = "default";
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	/* Half-quad decode (vendor ESP32Encoder::attachHalfQuad):
+	 * both edges of the signal input count, control input inverts.
+	 * 2100 counts per wheel revolution (Waveshare RaspRover).
+	 */
+	pcnt_unit0: unit0@0 {
+		reg = <0>;
+		counts-per-revolution = <2100>;
+		filter = <800>; /* 10 us at 80 MHz APB */
+		sig-pos-mode = <2>;
+		sig-neg-mode = <1>;
+		ctrl-h-mode = <0>;
+		ctrl-l-mode = <1>;
+	};
+
+	pcnt_unit1: unit1@1 {
+		reg = <1>;
+		counts-per-revolution = <2100>;
+		filter = <800>;
+		sig-pos-mode = <2>;
+		sig-neg-mode = <1>;
+		ctrl-h-mode = <0>;
+		ctrl-l-mode = <1>;
+	};
 };

--- a/drivers/sensor/CMakeLists.txt
+++ b/drivers/sensor/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory_ifdef(CONFIG_AS7341 as7341)
 add_subdirectory_ifdef(CONFIG_SINGLETACT singletact)
 add_subdirectory_ifdef(CONFIG_ADAFRUIT_SEESAW_ENCODER adafruit_seesaw_encoder)
+add_subdirectory_ifdef(CONFIG_ESP32_PCNT_ENCODER esp32_pcnt_encoder)

--- a/drivers/sensor/Kconfig
+++ b/drivers/sensor/Kconfig
@@ -2,4 +2,5 @@ if SENSOR
 rsource "as7341/Kconfig"
 rsource "singletact/Kconfig"
 rsource "adafruit_seesaw_encoder/Kconfig"
+rsource "esp32_pcnt_encoder/Kconfig"
 endif # SENSOR

--- a/drivers/sensor/esp32_pcnt_encoder/CMakeLists.txt
+++ b/drivers/sensor/esp32_pcnt_encoder/CMakeLists.txt
@@ -1,0 +1,2 @@
+zephyr_library()
+zephyr_library_sources_ifdef(CONFIG_ESP32_PCNT_ENCODER esp32_pcnt_encoder.c)

--- a/drivers/sensor/esp32_pcnt_encoder/Kconfig
+++ b/drivers/sensor/esp32_pcnt_encoder/Kconfig
@@ -1,0 +1,17 @@
+config ESP32_PCNT_ENCODER
+	bool "ESP32 PCNT multi-unit encoder"
+	default y
+	depends on DT_HAS_ROSTERLOH_ESP32_PCNT_ENABLED
+	depends on PINCTRL
+	help
+	  Encoder driver for the ESP32 pulse counter (PCNT) block. Each unit
+	  child node becomes its own sensor device reporting accumulated
+	  position on SENSOR_CHAN_ROTATION (degrees), with 16-bit hardware
+	  overflow folded into a 64-bit software accumulator via limit-event
+	  interrupts.
+
+if ESP32_PCNT_ENCODER
+module = ESP32_PCNT_ENCODER
+module-str = esp32_pcnt_encoder
+source "subsys/logging/Kconfig.template.log_config"
+endif

--- a/drivers/sensor/esp32_pcnt_encoder/esp32_pcnt_encoder.c
+++ b/drivers/sensor/esp32_pcnt_encoder/esp32_pcnt_encoder.c
@@ -12,7 +12,6 @@
 #define DT_DRV_COMPAT rosterloh_esp32_pcnt
 
 /* Include esp-idf headers first to avoid redefining BIT() macro */
-#include <hal/pcnt_hal.h>
 #include <hal/pcnt_ll.h>
 
 #include <soc.h>
@@ -51,11 +50,11 @@ struct pcnt_enc_unit_config {
 
 /* Controller-level state shared by all unit devices (single PCNT block). */
 static struct {
-	pcnt_hal_context_t hal;
+	pcnt_dev_t *dev;
 	bool initialized;
 	struct pcnt_enc_unit_data *units[PCNT_ENC_MAX_UNITS];
 } pcnt_enc_shared = {
-	.hal = {.dev = (pcnt_dev_t *)DT_INST_REG_ADDR(0)},
+	.dev = (pcnt_dev_t *)DT_INST_REG_ADDR(0),
 };
 
 PINCTRL_DT_INST_DEFINE(0);
@@ -64,7 +63,7 @@ static const struct pinctrl_dev_config *pcnt_enc_pincfg = PINCTRL_DT_INST_DEV_CO
 static void IRAM_ATTR pcnt_enc_isr(void *arg)
 {
 	ARG_UNUSED(arg);
-	pcnt_dev_t *hw = pcnt_enc_shared.hal.dev;
+	pcnt_dev_t *hw = pcnt_enc_shared.dev;
 	uint32_t intr_status = pcnt_ll_get_intr_status(hw);
 
 	pcnt_ll_clear_intr_status(hw, intr_status);
@@ -100,8 +99,6 @@ static int pcnt_enc_global_init(void)
 		return err;
 	}
 
-	pcnt_hal_init(&pcnt_enc_shared.hal, 0);
-
 	err = esp_intr_alloc(DT_INST_IRQ_BY_IDX(0, 0, irq),
 			     ESP_PRIO_TO_FLAGS(DT_INST_IRQ_BY_IDX(0, 0, priority)) |
 				     ESP_INT_FLAGS_CHECK(DT_INST_IRQ_BY_IDX(0, 0, flags)) |
@@ -127,7 +124,7 @@ static int pcnt_enc_sample_fetch(const struct device *dev, enum sensor_channel c
 
 	unsigned int key = irq_lock();
 
-	data->total = data->acc + pcnt_ll_get_count(pcnt_enc_shared.hal.dev, cfg->idx);
+	data->total = data->acc + pcnt_ll_get_count(pcnt_enc_shared.dev, cfg->idx);
 	irq_unlock(key);
 
 	return 0;
@@ -164,7 +161,7 @@ static int pcnt_enc_unit_init(const struct device *dev)
 			return err;
 		}
 	}
-	hw = pcnt_enc_shared.hal.dev;
+	hw = pcnt_enc_shared.dev;
 
 	pcnt_enc_shared.units[cfg->idx] = data;
 

--- a/drivers/sensor/esp32_pcnt_encoder/esp32_pcnt_encoder.c
+++ b/drivers/sensor/esp32_pcnt_encoder/esp32_pcnt_encoder.c
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2026 Richard Osterloh <richard.osterloh@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Multi-unit encoder driver for the ESP32 PCNT block. Each enabled unit
+ * child node of the rosterloh,esp32-pcnt controller is its own sensor
+ * device. The 16-bit hardware counter is extended to 64 bits by
+ * accumulating high/low-limit events in an ISR (the hardware clears the
+ * counter to zero whenever a limit is hit).
+ */
+
+#define DT_DRV_COMPAT rosterloh_esp32_pcnt
+
+/* Include esp-idf headers first to avoid redefining BIT() macro */
+#include <hal/pcnt_hal.h>
+#include <hal/pcnt_ll.h>
+
+#include <soc.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/interrupt_controller/intc_esp32.h>
+#include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(esp32_pcnt_encoder, CONFIG_ESP32_PCNT_ENCODER_LOG_LEVEL);
+
+#define PCNT_ENC_LIMIT 30000
+
+/* Raw unit status bits (pcnt_ll_get_unit_status) */
+#define PCNT_ENC_STATUS_LOW_LIMIT  BIT(4)
+#define PCNT_ENC_STATUS_HIGH_LIMIT BIT(5)
+
+#define PCNT_ENC_MAX_UNITS 8
+
+struct pcnt_enc_unit_data {
+	int64_t acc;   /* limit-event accumulator, ISR-updated */
+	int64_t total; /* snapshot taken by sample_fetch */
+};
+
+struct pcnt_enc_unit_config {
+	uint8_t idx;
+	uint16_t filter;
+	uint32_t counts_per_rev;
+	uint8_t sig_pos_mode;
+	uint8_t sig_neg_mode;
+	uint8_t ctrl_h_mode;
+	uint8_t ctrl_l_mode;
+};
+
+/* Controller-level state shared by all unit devices (single PCNT block). */
+static struct {
+	pcnt_hal_context_t hal;
+	bool initialized;
+	struct pcnt_enc_unit_data *units[PCNT_ENC_MAX_UNITS];
+} pcnt_enc_shared = {
+	.hal = {.dev = (pcnt_dev_t *)DT_INST_REG_ADDR(0)},
+};
+
+PINCTRL_DT_INST_DEFINE(0);
+static const struct pinctrl_dev_config *pcnt_enc_pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0);
+
+static void IRAM_ATTR pcnt_enc_isr(void *arg)
+{
+	ARG_UNUSED(arg);
+	pcnt_dev_t *hw = pcnt_enc_shared.hal.dev;
+	uint32_t intr_status = pcnt_ll_get_intr_status(hw);
+
+	pcnt_ll_clear_intr_status(hw, intr_status);
+
+	for (int i = 0; i < PCNT_ENC_MAX_UNITS; i++) {
+		if (!(intr_status & BIT(i)) || pcnt_enc_shared.units[i] == NULL) {
+			continue;
+		}
+		uint32_t st = pcnt_ll_get_unit_status(hw, i);
+
+		if (st & PCNT_ENC_STATUS_HIGH_LIMIT) {
+			pcnt_enc_shared.units[i]->acc += PCNT_ENC_LIMIT;
+		} else if (st & PCNT_ENC_STATUS_LOW_LIMIT) {
+			pcnt_enc_shared.units[i]->acc -= PCNT_ENC_LIMIT;
+		}
+	}
+}
+
+static int pcnt_enc_global_init(void)
+{
+	int err;
+	const struct device *clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(0));
+
+	err = clock_control_on(clock_dev, (clock_control_subsys_t)DT_INST_CLOCKS_CELL(0, offset));
+	if (err < 0) {
+		LOG_ERR("clock enable failed (%d)", err);
+		return err;
+	}
+
+	err = pinctrl_apply_state(pcnt_enc_pincfg, PINCTRL_STATE_DEFAULT);
+	if (err < 0) {
+		LOG_ERR("pinctrl apply failed (%d)", err);
+		return err;
+	}
+
+	pcnt_hal_init(&pcnt_enc_shared.hal, 0);
+
+	err = esp_intr_alloc(DT_INST_IRQ_BY_IDX(0, 0, irq),
+			     ESP_PRIO_TO_FLAGS(DT_INST_IRQ_BY_IDX(0, 0, priority)) |
+				     ESP_INT_FLAGS_CHECK(DT_INST_IRQ_BY_IDX(0, 0, flags)) |
+				     ESP_INTR_FLAG_IRAM,
+			     pcnt_enc_isr, NULL, NULL);
+	if (err != 0) {
+		LOG_ERR("isr alloc failed (%d)", err);
+		return err;
+	}
+
+	pcnt_enc_shared.initialized = true;
+	return 0;
+}
+
+static int pcnt_enc_sample_fetch(const struct device *dev, enum sensor_channel chan)
+{
+	const struct pcnt_enc_unit_config *cfg = dev->config;
+	struct pcnt_enc_unit_data *data = dev->data;
+
+	if (chan != SENSOR_CHAN_ALL && chan != SENSOR_CHAN_ROTATION) {
+		return -ENOTSUP;
+	}
+
+	unsigned int key = irq_lock();
+
+	data->total = data->acc + pcnt_ll_get_count(pcnt_enc_shared.hal.dev, cfg->idx);
+	irq_unlock(key);
+
+	return 0;
+}
+
+static int pcnt_enc_channel_get(const struct device *dev, enum sensor_channel chan,
+				struct sensor_value *val)
+{
+	const struct pcnt_enc_unit_config *cfg = dev->config;
+	struct pcnt_enc_unit_data *data = dev->data;
+
+	if (chan != SENSOR_CHAN_ROTATION) {
+		return -ENOTSUP;
+	}
+
+	/* counts -> micro-degrees, then split into sensor_value */
+	int64_t udeg = data->total * 360LL * 1000000LL / cfg->counts_per_rev;
+
+	val->val1 = (int32_t)(udeg / 1000000LL);
+	val->val2 = (int32_t)(udeg % 1000000LL);
+	return 0;
+}
+
+static int pcnt_enc_unit_init(const struct device *dev)
+{
+	const struct pcnt_enc_unit_config *cfg = dev->config;
+	struct pcnt_enc_unit_data *data = dev->data;
+	pcnt_dev_t *hw;
+	int err;
+
+	if (!pcnt_enc_shared.initialized) {
+		err = pcnt_enc_global_init();
+		if (err < 0) {
+			return err;
+		}
+	}
+	hw = pcnt_enc_shared.hal.dev;
+
+	pcnt_enc_shared.units[cfg->idx] = data;
+
+	pcnt_ll_stop_count(hw, cfg->idx);
+	pcnt_ll_disable_all_events(hw, cfg->idx);
+
+	/* Channel 0 carries the encoder; channel 1 must not count. */
+	pcnt_ll_set_edge_action(hw, cfg->idx, 0, cfg->sig_pos_mode, cfg->sig_neg_mode);
+	pcnt_ll_set_level_action(hw, cfg->idx, 0, cfg->ctrl_h_mode, cfg->ctrl_l_mode);
+	pcnt_ll_set_edge_action(hw, cfg->idx, 1, PCNT_CHANNEL_EDGE_ACTION_HOLD,
+				PCNT_CHANNEL_EDGE_ACTION_HOLD);
+	pcnt_ll_set_level_action(hw, cfg->idx, 1, PCNT_CHANNEL_LEVEL_ACTION_KEEP,
+				 PCNT_CHANNEL_LEVEL_ACTION_KEEP);
+
+	pcnt_ll_set_high_limit_value(hw, cfg->idx, PCNT_ENC_LIMIT);
+	pcnt_ll_set_low_limit_value(hw, cfg->idx, -PCNT_ENC_LIMIT);
+	pcnt_ll_enable_high_limit_event(hw, cfg->idx, true);
+	pcnt_ll_enable_low_limit_event(hw, cfg->idx, true);
+
+	pcnt_ll_set_glitch_filter_thres(hw, cfg->idx, cfg->filter);
+	pcnt_ll_enable_glitch_filter(hw, cfg->idx, cfg->filter != 0);
+
+	pcnt_ll_clear_count(hw, cfg->idx);
+	pcnt_ll_enable_intr(hw, BIT(cfg->idx), true);
+	pcnt_ll_start_count(hw, cfg->idx);
+
+	return 0;
+}
+
+static DEVICE_API(sensor, pcnt_enc_api) = {
+	.sample_fetch = pcnt_enc_sample_fetch,
+	.channel_get = pcnt_enc_channel_get,
+};
+
+#define PCNT_ENC_UNIT_DEFINE(node_id)                                                              \
+	static struct pcnt_enc_unit_data pcnt_enc_data_##node_id;                                  \
+	static const struct pcnt_enc_unit_config pcnt_enc_cfg_##node_id = {                        \
+		.idx = DT_REG_ADDR(node_id),                                                       \
+		.filter = MIN(DT_PROP(node_id, filter), PCNT_LL_MAX_GLITCH_WIDTH),                 \
+		.counts_per_rev = DT_PROP(node_id, counts_per_revolution),                         \
+		.sig_pos_mode = DT_PROP(node_id, sig_pos_mode),                                    \
+		.sig_neg_mode = DT_PROP(node_id, sig_neg_mode),                                    \
+		.ctrl_h_mode = DT_PROP(node_id, ctrl_h_mode),                                      \
+		.ctrl_l_mode = DT_PROP(node_id, ctrl_l_mode),                                      \
+	};                                                                                         \
+	SENSOR_DEVICE_DT_DEFINE(node_id, pcnt_enc_unit_init, NULL, &pcnt_enc_data_##node_id,       \
+				&pcnt_enc_cfg_##node_id, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, \
+				&pcnt_enc_api);
+
+DT_INST_FOREACH_CHILD_STATUS_OKAY(0, PCNT_ENC_UNIT_DEFINE)

--- a/drivers/sensor/esp32_pcnt_encoder/esp32_pcnt_encoder.c
+++ b/drivers/sensor/esp32_pcnt_encoder/esp32_pcnt_encoder.c
@@ -197,6 +197,9 @@ static DEVICE_API(sensor, pcnt_enc_api) = {
 };
 
 #define PCNT_ENC_UNIT_DEFINE(node_id)                                                              \
+	BUILD_ASSERT(DT_REG_ADDR(node_id) < PCNT_ENC_MAX_UNITS, "PCNT unit index out of range");   \
+	BUILD_ASSERT(DT_PROP(node_id, counts_per_revolution) > 0,                                  \
+		     "counts-per-revolution must be positive");                                    \
 	static struct pcnt_enc_unit_data pcnt_enc_data_##node_id;                                  \
 	static const struct pcnt_enc_unit_config pcnt_enc_cfg_##node_id = {                        \
 		.idx = DT_REG_ADDR(node_id),                                                       \

--- a/dts/bindings/sensor/rosterloh,esp32-pcnt.yaml
+++ b/dts/bindings/sensor/rosterloh,esp32-pcnt.yaml
@@ -1,0 +1,79 @@
+description: |
+  ESP32 PCNT pulse-counter block exposing each counting unit as its own
+  encoder sensor device.
+
+  Unlike the upstream espressif,esp32-pcnt sensor driver (which only reports
+  unit 0), every enabled unit child node here becomes an independent Zephyr
+  device, so multiple encoders (e.g. one per wheel) can be read separately.
+  Apply this compatible to the SoC's pcnt node in a board dts to replace the
+  upstream driver.
+
+  Each unit uses PCNT channel 0 only: the signal input counts edges, the
+  control input optionally gates/inverts the count direction. The vendor
+  half-quad scheme (ESP32Encoder::attachHalfQuad) is sig-pos-mode = 2,
+  sig-neg-mode = 1, ctrl-h-mode = 0, ctrl-l-mode = 1.
+
+  The 16-bit hardware counter wraps at +/-30000 via high/low limit events
+  that the driver accumulates into a 64-bit software total. The accumulated
+  count is reported on SENSOR_CHAN_ROTATION in degrees, scaled by
+  counts-per-revolution.
+
+compatible: "rosterloh,esp32-pcnt"
+
+include: [base.yaml, pinctrl-device.yaml]
+
+child-binding:
+  description: PCNT unit configured as an encoder input.
+
+  properties:
+    reg:
+      type: int
+      required: true
+      description: PCNT unit index (0..7 on ESP32).
+
+    counts-per-revolution:
+      type: int
+      required: true
+      description: |
+        Hardware counts per revolution of the measured shaft, including any
+        decode multiplier and gearbox ratio. Used to scale counts to degrees
+        for SENSOR_CHAN_ROTATION.
+
+    filter:
+      type: int
+      default: 0
+      description: |
+        Glitch filter threshold in APB clock cycles (80 MHz: 800 = 10 us).
+        0 disables the filter. Hardware maximum is 1023.
+
+    sig-pos-mode:
+      type: int
+      default: 1
+      enum: [0, 1, 2]
+      description: |
+        Action on positive edge of the signal input.
+        0 = hold, 1 = increment, 2 = decrement.
+
+    sig-neg-mode:
+      type: int
+      default: 0
+      enum: [0, 1, 2]
+      description: |
+        Action on negative edge of the signal input.
+        0 = hold, 1 = increment, 2 = decrement.
+
+    ctrl-h-mode:
+      type: int
+      default: 0
+      enum: [0, 1, 2]
+      description: |
+        Modifier while the control input is high.
+        0 = keep, 1 = invert, 2 = hold.
+
+    ctrl-l-mode:
+      type: int
+      default: 0
+      enum: [0, 1, 2]
+      description: |
+        Modifier while the control input is low.
+        0 = keep, 1 = invert, 2 = hold.


### PR DESCRIPTION
## Summary
- Add a multi-unit ESP32 PCNT encoder sensor driver, with one sensor device per PCNT unit and 64-bit accumulation through limit-event interrupts.
- Wire the Waveshare ROS Driver board motor hardware: LEDC channels 2/3, PCNT units 0/1 in half-quad mode, h-bridge nodes, encoder phandles, and left/right motor aliases.
- Preserve vendor motor polarity, 100 kHz PWM, and RaspRover encoder constants from the implementation spec.

## Verification
- uv run poe agent-build rasprover --sysbuild
- uv run poe agent-build rasprover --board native_sim/native/64
- timeout 5 ./builds/rasprover/zephyr/zephyr.exe (expected timeout after motor init log)

This is the module dependency for rosterloh/zephyr-applications feat/rasprover-motors.