### PR TITLE
boards: waveshare/ros_driver: point i2c0 recovery GPIOs at gpio1

### DIFF
--- a/boards/waveshare/ros_driver/ros_driver_procpu.dts
+++ b/boards/waveshare/ros_driver/ros_driver_procpu.dts
@@ -157,8 +157,11 @@
 &i2c0 {
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
-	sda-gpios = <&gpio0 32 GPIO_OPEN_DRAIN>;
-	scl-gpios = <&gpio0 33 GPIO_OPEN_DRAIN>;
+	/* GPIO32/33 live on the gpio1 controller (pins 0/1); gpio0 only covers
+	 * 0..31. These specs drive the i2c_esp32 bit-bang bus-recovery, so they
+	 * must reference the correct controller or recovery silently no-ops. */
+	sda-gpios = <&gpio1 0 GPIO_OPEN_DRAIN>;
+	scl-gpios = <&gpio1 1 GPIO_OPEN_DRAIN>;
 	pinctrl-0 = <&i2c0_default>;
 	pinctrl-names = "default";
 


### PR DESCRIPTION
i2c0 SDA/SCL are GPIO32/GPIO33, which live on the gpio1 controller (pin index 0/1); gpio0 only covers GPIO0..31. The sda-gpios/scl-gpios specs drive the esp32 I2C bit-bang bus recovery, so referencing gpio0 with pin 32/33 was out of range and made recovery a silent no-op -- a slave holding SDA low could never be clocked free, wedging the bus.

Pair with the i2c_esp32 driver fix that reattaches the bus via pinctrl after bit-banging.