### PR TITLE
subsys: net: add wifi_connectivity conn_mgr implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,5 +8,6 @@ zephyr_include_directories(include)
 
 add_subdirectory(drivers)
 add_subdirectory_ifdef(CONFIG_ACTUATOR subsys/actuator)
+add_subdirectory_ifdef(CONFIG_WIFI_CONNECTIVITY subsys/net/wifi_connectivity)
 add_subdirectory_ifdef(CONFIG_ACTUATOR_LIB lib/actuator)
 add_subdirectory_ifdef(CONFIG_KINEMATICS lib/kinematics)

--- a/Kconfig
+++ b/Kconfig
@@ -1,4 +1,5 @@
 rsource "drivers/Kconfig"
 rsource "subsys/actuator/Kconfig"
+rsource "subsys/net/wifi_connectivity/Kconfig"
 rsource "lib/actuator/Kconfig"
 rsource "lib/kinematics/Kconfig"

--- a/subsys/net/wifi_connectivity/CMakeLists.txt
+++ b/subsys/net/wifi_connectivity/CMakeLists.txt
@@ -1,0 +1,2 @@
+zephyr_library_named(wifi_connectivity)
+zephyr_library_sources(wifi_connectivity.c)

--- a/subsys/net/wifi_connectivity/Kconfig
+++ b/subsys/net/wifi_connectivity/Kconfig
@@ -1,0 +1,36 @@
+menuconfig WIFI_CONNECTIVITY
+	bool "conn_mgr connectivity for WiFi using stored credentials"
+	depends on NET_CONNECTION_MANAGER_CONNECTIVITY_WIFI_MGMT
+	depends on WIFI_CREDENTIALS
+	depends on WIFI_CREDENTIALS_CONNECT_STORED
+	help
+	  Implements the CONNECTIVITY_WIFI_MGMT conn_mgr binding declared by
+	  WiFi drivers. Connects with credentials from the wifi_credentials
+	  subsystem (NET_REQUEST_WIFI_CONNECT_STORED), starts DHCPv4 once
+	  associated and, while the interface is persistent, retries failed
+	  attempts and re-establishes lost connections. Supports a single
+	  WiFi interface.
+
+if WIFI_CONNECTIVITY
+
+module = WIFI_CONNECTIVITY
+module-str = wifi_connectivity
+source "subsys/logging/Kconfig.template.log_config"
+
+config WIFI_CONNECTIVITY_PERSISTENCE
+	bool "Enable connection persistence by default"
+	default y
+	help
+	  Sets CONN_MGR_IF_PERSISTENT on the bound WiFi interface at init so
+	  that lost connections are re-established automatically. Can be
+	  changed at runtime with conn_mgr_if_set_flag().
+
+config WIFI_CONNECTIVITY_RECONNECT_DELAY_SECONDS
+	int "Delay between reconnect attempts"
+	default 5
+	help
+	  Seconds to wait after a failed connection attempt, an unsolicited
+	  disconnect, or a connect issued with no stored credentials before
+	  trying NET_REQUEST_WIFI_CONNECT_STORED again.
+
+endif # WIFI_CONNECTIVITY

--- a/subsys/net/wifi_connectivity/wifi_connectivity.c
+++ b/subsys/net/wifi_connectivity/wifi_connectivity.c
@@ -1,0 +1,162 @@
+/*
+ * conn_mgr connectivity implementation for WiFi drivers that bind
+ * CONNECTIVITY_WIFI_MGMT (the CONNECTIVITY_WIFI_MGMT_APPLICATION choice).
+ *
+ * Association parameters come from the wifi_credentials subsystem via
+ * NET_REQUEST_WIFI_CONNECT_STORED. Persistence (CONN_MGR_IF_PERSISTENT)
+ * is honoured by retrying failed attempts and unsolicited disconnects on
+ * a delayable work item; a connect issued before any credentials are
+ * stored keeps polling so the interface comes up once credentials are
+ * provisioned (e.g. via `wifi cred add`).
+ */
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(wifi_connectivity, CONFIG_WIFI_CONNECTIVITY_LOG_LEVEL);
+
+#include <zephyr/kernel.h>
+#include <zephyr/net/conn_mgr_connectivity.h>
+#include <zephyr/net/conn_mgr_connectivity_impl.h>
+#include <zephyr/net/dhcpv4.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/net_mgmt.h>
+#include <zephyr/net/wifi_credentials.h>
+#include <zephyr/net/wifi_mgmt.h>
+
+#define RECONNECT_DELAY K_SECONDS(CONFIG_WIFI_CONNECTIVITY_RECONNECT_DELAY_SECONDS)
+
+static struct net_if *wifi_iface;
+static struct net_mgmt_event_callback wifi_mgmt_cb;
+static struct k_work_delayable reconnect_work;
+static bool disconnect_requested;
+
+static bool creds_available(void)
+{
+	return IS_ENABLED(CONFIG_WIFI_CREDENTIALS_STATIC) || !wifi_credentials_is_empty();
+}
+
+static void schedule_reconnect(struct net_if *iface)
+{
+	if (!conn_mgr_if_get_flag(iface, CONN_MGR_IF_PERSISTENT)) {
+		return;
+	}
+
+	if (!net_if_is_admin_up(iface)) {
+		return;
+	}
+
+	k_work_reschedule(&reconnect_work, RECONNECT_DELAY);
+}
+
+static void reconnect_handler(struct k_work *work)
+{
+	int err;
+
+	ARG_UNUSED(work);
+
+	if (!net_if_is_admin_up(wifi_iface)) {
+		return;
+	}
+
+	err = conn_mgr_if_connect(wifi_iface);
+	if (err && err != -EALREADY) {
+		LOG_DBG("Reconnect attempt failed: %d", err);
+		schedule_reconnect(wifi_iface);
+	}
+}
+
+static void wifi_mgmt_event_handler(struct net_mgmt_event_callback *cb, uint64_t mgmt_event,
+				    struct net_if *iface)
+{
+	const struct wifi_status *status = cb->info;
+
+	if (iface != wifi_iface) {
+		return;
+	}
+
+	switch (mgmt_event) {
+	case NET_EVENT_WIFI_CONNECT_RESULT:
+		if (status->status) {
+			LOG_WRN("Connection attempt failed (%d)", status->status);
+			schedule_reconnect(iface);
+		} else {
+			LOG_INF("Connected");
+			if (IS_ENABLED(CONFIG_NET_DHCPV4)) {
+				net_dhcpv4_start(iface);
+			}
+		}
+		break;
+	case NET_EVENT_WIFI_DISCONNECT_RESULT:
+		if (disconnect_requested) {
+			disconnect_requested = false;
+		} else {
+			LOG_INF("Disconnected (%d)", status->status);
+			schedule_reconnect(iface);
+		}
+		break;
+	default:
+		break;
+	}
+}
+
+static bool wc_has_config(struct conn_mgr_conn_binding *const binding)
+{
+	ARG_UNUSED(binding);
+
+	return creds_available();
+}
+
+static int wc_connect(struct conn_mgr_conn_binding *const binding)
+{
+	int err;
+
+	disconnect_requested = false;
+
+	if (!creds_available()) {
+		/* NET_REQUEST_WIFI_CONNECT_STORED silently does nothing without
+		 * stored credentials; poll until some are provisioned.
+		 */
+		LOG_INF("No WiFi credentials stored yet");
+		schedule_reconnect(binding->iface);
+		return 0;
+	}
+
+	err = net_mgmt(NET_REQUEST_WIFI_CONNECT_STORED, binding->iface, NULL, 0);
+	if (err == -EALREADY) {
+		return 0;
+	}
+
+	return err;
+}
+
+static int wc_disconnect(struct conn_mgr_conn_binding *const binding)
+{
+	disconnect_requested = true;
+	k_work_cancel_delayable(&reconnect_work);
+
+	return net_mgmt(NET_REQUEST_WIFI_DISCONNECT, binding->iface, NULL, 0);
+}
+
+static void wc_init(struct conn_mgr_conn_binding *const binding)
+{
+	__ASSERT(wifi_iface == NULL, "only one WiFi interface is supported");
+	wifi_iface = binding->iface;
+
+	if (IS_ENABLED(CONFIG_WIFI_CONNECTIVITY_PERSISTENCE)) {
+		binding->flags |= BIT(CONN_MGR_IF_PERSISTENT);
+	}
+
+	k_work_init_delayable(&reconnect_work, reconnect_handler);
+
+	net_mgmt_init_event_callback(&wifi_mgmt_cb, wifi_mgmt_event_handler,
+				     NET_EVENT_WIFI_CONNECT_RESULT |
+					     NET_EVENT_WIFI_DISCONNECT_RESULT);
+	net_mgmt_add_event_callback(&wifi_mgmt_cb);
+}
+
+static struct conn_mgr_conn_api wifi_connectivity_api = {
+	.connect = wc_connect,
+	.disconnect = wc_disconnect,
+	.has_connection_config = wc_has_config,
+	.init = wc_init,
+};
+
+CONN_MGR_CONN_DEFINE(CONNECTIVITY_WIFI_MGMT, &wifi_connectivity_api);


### PR DESCRIPTION
## Summary

Adds a `wifi_connectivity` subsystem implementing the `CONNECTIVITY_WIFI_MGMT` conn_mgr binding that Zephyr WiFi drivers (e.g. the ESP32 driver) declare, but that upstream deliberately leaves to the application (`CONNECTIVITY_WIFI_MGMT_APPLICATION` choice).

- **Connect** via `NET_REQUEST_WIFI_CONNECT_STORED`, so association parameters come from the `wifi_credentials` subsystem (runtime `wifi cred add` provisioning or `WIFI_CREDENTIALS_STATIC`).
- **DHCPv4** started on successful association; subsequent iface bounces are handled by the DHCP client's own event handling.
- **Persistence**: `CONN_MGR_IF_PERSISTENT` is set at init (Kconfig-controlled) and honoured with a delayable-work retry covering failed connection attempts, unsolicited disconnects, and connects issued before any credentials are stored — the last case polls until credentials are provisioned, so no reboot is required after `wifi cred add`.
- Single WiFi interface supported (asserted at init).

Kconfig: `CONFIG_WIFI_CONNECTIVITY`, `CONFIG_WIFI_CONNECTIVITY_PERSISTENCE` (default y), `CONFIG_WIFI_CONNECTIVITY_RECONNECT_DELAY_SECONDS` (default 5), plus a standard log-level template.

## Motivation

Replaces the per-app hand-rolled WiFi state machines duplicated across zephyr-applications (rasprover `app_network.c`, force_sensor/pico_fw `wifi.c` — ~1,460 lines combined) with ~150 shared lines composed from upstream subsystems (conn_mgr, wifi_credentials).

## Testing

- Consumed from the zephyr-applications workspace by the migrated rasprover app: `ros_driver/esp32/procpu` `--sysbuild` build is green (Zephyr main).
- `clang-format` clean.
- Downstream migration (thin L4-event wrapper + prj.conf) verified in rosterloh/zephyr-applications; hardware smoke test pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)