### PR TITLE
bus_servo: drain unicast write reply to avoid bus collision

### DIFF
--- a/drivers/bus_servo/bus_servo.c
+++ b/drivers/bus_servo/bus_servo.c
@@ -192,6 +192,15 @@ static int transact(int iface, uint8_t id, enum bus_servo_instruction instructio
 	if (rc != 0) {
 		goto unlock;
 	}
+	if (!expect_response && id != BUS_SERVO_BROADCAST_ID) {
+		/* A unicast write is acknowledged with a status packet even when
+		 * the caller does not read it. Drain that reply so it cannot
+		 * collide with the next transaction on the shared bus (which
+		 * silently dropped back-to-back single-servo writes). Broadcast
+		 * sync-writes are not acknowledged, so they skip this.
+		 */
+		bus_servo_drain_reply(ctx);
+	}
 	if (expect_response && ctx->status_error != 0) {
 		rc = -EIO;
 		goto unlock;

--- a/drivers/bus_servo/bus_servo_internal.h
+++ b/drivers/bus_servo/bus_servo_internal.h
@@ -38,6 +38,7 @@ uint8_t bus_servo_checksum(const uint8_t *data, size_t len);
 int bus_servo_serial_init(struct bus_servo_context *ctx, struct bus_servo_iface_param param);
 int bus_servo_tx_rx(struct bus_servo_context *ctx, const uint8_t *tx_buf, size_t tx_len,
 		    bool expect_response);
+void bus_servo_drain_reply(struct bus_servo_context *ctx);
 struct bus_servo_context *bus_servo_get_context(int iface);
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_BUS_SERVO_INTERNAL_H_ */

--- a/drivers/bus_servo/bus_servo_serial.c
+++ b/drivers/bus_servo/bus_servo_serial.c
@@ -14,6 +14,13 @@ LOG_MODULE_DECLARE(bus_servo, CONFIG_BUS_SERVO_LOG_LEVEL);
 #define BUS_SERVO_BITS_PER_BYTE   11
 #define BUS_SERVO_RX_DRAIN_LIMIT  BUS_SERVO_MAX_PACKET_SIZE
 
+/* Time to wait for a unicast write's status packet to start arriving before
+ * assuming the servo is configured not to reply, and the idle gap that marks
+ * the end of that reply once bytes have been seen.
+ */
+#define BUS_SERVO_REPLY_START_US 2000
+#define BUS_SERVO_BUS_IDLE_US    200
+
 static int set_tx_en(struct bus_servo_context *ctx, int value)
 {
 	struct bus_servo_serial_config *cfg = ctx->cfg;
@@ -214,6 +221,43 @@ static int rx_status_packet(struct bus_servo_context *ctx)
 	}
 
 	return -ETIMEDOUT;
+}
+
+void bus_servo_drain_reply(struct bus_servo_context *ctx)
+{
+	struct bus_servo_serial_config *cfg = ctx->cfg;
+	int64_t start_deadline = k_uptime_ticks() + k_us_to_ticks_ceil64(BUS_SERVO_REPLY_START_US);
+	int64_t idle_deadline = 0;
+	bool seen = false;
+	unsigned char byte;
+
+	/* A unicast write leaves a status packet on the shared half-duplex bus
+	 * (unless the servo's status-return is disabled). Consume it so it does
+	 * not collide with the next transaction's transmission. Wait up to
+	 * BUS_SERVO_REPLY_START_US for the reply to begin, then discard bytes
+	 * until the bus has been idle for BUS_SERVO_BUS_IDLE_US.
+	 */
+	while (true) {
+		int rc = uart_poll_in(cfg->dev, &byte);
+
+		if (rc == 0) {
+			seen = true;
+			idle_deadline =
+				k_uptime_ticks() + k_us_to_ticks_ceil64(BUS_SERVO_BUS_IDLE_US);
+			continue;
+		}
+		if (rc != -1) {
+			return; /* unexpected UART error, give up */
+		}
+		if (seen) {
+			if (k_uptime_ticks() >= idle_deadline) {
+				return; /* reply received, bus idle */
+			}
+		} else if (k_uptime_ticks() >= start_deadline) {
+			return; /* servo did not reply */
+		}
+		k_busy_wait(20);
+	}
 }
 
 int bus_servo_tx_rx(struct bus_servo_context *ctx, const uint8_t *tx_buf, size_t tx_len,


### PR DESCRIPTION
## Problem
A unicast write is acknowledged by the addressed servo with a status packet, even when the caller doesn't read it (`expect_response=false`). `transact()` returned immediately after transmitting, so the **next** transaction's TX collided with that still-in-flight reply on the shared half-duplex bus. The following command was corrupted and silently dropped.

Symptom: back-to-back single-servo writes (e.g. `actuator_set_position(pan)` then `actuator_set_position(tilt)`) only moved the **first** servo; the second silently didn't move despite the call returning success. (Broadcast sync-write was unaffected, which is why the group path worked.)

## Fix
After a **unicast** write, drain and discard the servo's status reply so it can't collide with the next transaction. Bounded by:
- a short first-byte timeout (`BUS_SERVO_REPLY_START_US`, 2 ms) — tolerates servos with status-return disabled, and
- a bus-idle gap (`BUS_SERVO_BUS_IDLE_US`, 200 µs) marking the end of the reply.

Broadcast sync-writes (id `0xfe`) are **not** acknowledged, so they skip the drain and keep their throughput.

## Verified on hardware
ST3215 servos over the XIAO ESP32-C5 UART bus (1 Mbaud). With the app temporarily forced back to two back-to-back unicast writes: commanding pan −0.495→0.6 and tilt 0.103→0.8 in one MCP call now lands **both** at target (`pan=0.594, tilt=0.796`), where previously tilt stayed put. `pt_mcp` (the group-sync-write consumer) still builds and runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)